### PR TITLE
リンクエリアの改善（記事一覧とPopularの部分）

### DIFF
--- a/assets/js/kikoiro1.js
+++ b/assets/js/kikoiro1.js
@@ -246,4 +246,14 @@ $(function() {
 			});
 		}
 	}
+	$('div.postCategories').hover(
+	    function() {
+	        $(this).parent().find('h3 span').css({'border-bottom': '1px solid transparent'});
+	        $(this).parent().find('figure').css({'opacity': '1'});
+	    },
+	    function() {
+	        $(this).parent().find('h3 span').css({'border-bottom': ''});
+	        $(this).parent().find('figure').css({'opacity': ''});	        
+	    }
+	);
 });

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
 Theme Name: kikoiro1
 Author: Hironobu Kimura
 Author URI: https://www.emotionale.jp/
-Version: 2.52
+Version: 2.53
 
 kikoiro1 is based on Underscores twentynineteen by WordPress team.
 twentynineteen is distributed under the terms of the GNU GPL v2 or later.

--- a/style.css
+++ b/style.css
@@ -857,11 +857,11 @@ div.items {
     margin: 0 0 48px 0;
     display: block;
     width: 280px;
-    line-height: 150%;
-    cursor: pointer; }
+    line-height: 150%; }
     div.items article a {
       color: #000000;
-      display: block; }
+      display: inline-block;
+      cursor: pointer; }
       @media (hover: hover) {
       div.items article:hover figure {
           opacity: 0.7; }
@@ -1002,12 +1002,7 @@ span.showMore {
 div.postCategories {
   margin: 12px 0 4px 0; }
 
-a.postCategories {
-  display: block;
-  padding: 12px 0 4px 0; }
-
-a.categoryTag,
-span.categoryTag {
+a.categoryTag {
   background-color: #CCECC6;
   font-size: 11px;
   display: inline-block;

--- a/style.css
+++ b/style.css
@@ -858,19 +858,21 @@ div.items {
     display: block;
     width: 280px;
     line-height: 150%; }
+    div.items article > a {
+      color: #000000;
+      cursor: pointer;
+      display: block; }
+      @media (hover: hover) {
+        div.items article > a:hover figure {
+          opacity: 0.7; }
+        div.items article > a:hover h3 span {
+          border-bottom: 1px solid #636363; } }
     div.items article figure {
       margin: 0;
       height: 210px;
-      background: #ffffff; }
-      div.items article figure a {
-        -webkit-transition: opacity 0.3s;
-        -o-transition: opacity 0.3s;
+      background: #ffffff;
         transition: opacity 0.3s; }
-        @media (hover: hover) {
-          div.items article figure a:hover {
-            opacity: 0.7;
-            cursor: pointer; } }
-        div.items article figure a img {
+      div.items article figure img {
           width: 280px;
           height: 210px;
           -o-object-fit: cover;
@@ -879,6 +881,9 @@ div.items {
       font-size: 18ox;
       line-height: 150%;
       margin: 0 0 6px 0; }
+      div.items article h3 span {
+        border-bottom: 1px solid transparent;
+        transition: border-color 0.2s; }
     div.items article div.entry-content p {
       margin: 0; }
     div.items article div.postDate {
@@ -997,7 +1002,8 @@ span.showMore {
 div.postCategories {
   margin: 12px 0 4px 0; }
 
-a.categoryTag {
+a.categoryTag,
+span.categoryTag {
   background-color: #CCECC6;
   font-size: 11px;
   display: inline-block;
@@ -1075,29 +1081,43 @@ section.widget_top-posts ul {
   padding: 0; }
   section.widget_top-posts ul li {
     margin: 0 0 16px 0;
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex; }
+    @media (hover: hover) {
+      section.widget_top-posts ul li:hover img {
+        cursor: pointer;
+        opacity: 0.7; }
+      section.widget_top-posts ul li:hover div.widgets-list-layout-links a {
+        border-bottom: 1px solid #636363; } }
     section.widget_top-posts ul li a img {
       float: none;
       max-width: 48px !important;
       width: 48px !important;
       height: 48px !important;
-      -webkit-transition: opacity 0.3s;
-      -o-transition: opacity 0.3s;
       transition: opacity 0.3s; }
-      @media (hover: hover) {
-        section.widget_top-posts ul li a img {
-          float: none; }
-          section.widget_top-posts ul li a img:hover {
-            cursor: pointer;
-            opacity: 0.7; } }
     section.widget_top-posts ul li div.widgets-list-layout-links {
       float: none;
       width: auto;
-      margin-left: 8px;
       display: inline-block;
-      line-height: 150%; }
+      line-height: 150%;
+      position: relative;
+      width: 100%; }
+      section.widget_top-posts ul li div.widgets-list-layout-links a {
+        border-bottom: 1px solid transparent;
+        transition: border-color 0.2s; }
+        section.widget_top-posts ul li div.widgets-list-layout-links a:before {
+          content: "";
+          display: inline-block;
+          width: 8px;
+          height: 48px;
+          float: left; }
+        section.widget_top-posts ul li div.widgets-list-layout-links a:after {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: 1; }
 
 /* WP Popular Post */
 #wpp-8 ul {
@@ -2110,11 +2130,11 @@ iframe {
     grid-column-gap: 12px !important; }
     div.items article {
       width: calc((100vw - 36px) / 2); }
-      div.items article figure {
+      div.items article a figure {
         margin: 0;
         height: calc(((100vw - 36px) / 2) / 4 * 3);
         background: transparent; }
-        div.items article figure a img {
+        div.items article a figure img {
           width: calc((100vw - 36px) / 2);
           height: calc(((100vw - 36px) / 2) / 4 * 3); }
       div.items article h3 {

--- a/style.css
+++ b/style.css
@@ -857,22 +857,22 @@ div.items {
     margin: 0 0 48px 0;
     display: block;
     width: 280px;
-    line-height: 150%; }
-    div.items article > a {
+    line-height: 150%;
+    cursor: pointer; }
+    div.items article a {
       color: #000000;
-      cursor: pointer;
       display: block; }
       @media (hover: hover) {
-        div.items article > a:hover figure {
+      div.items article:hover figure {
           opacity: 0.7; }
-        div.items article > a:hover h3 span {
+      div.items article:hover h3 span {
           border-bottom: 1px solid #636363; } }
     div.items article figure {
       margin: 0;
       height: 210px;
       background: #ffffff;
         transition: opacity 0.3s; }
-      div.items article figure img {
+      div.items article figure a img {
           width: 280px;
           height: 210px;
           -o-object-fit: cover;
@@ -1001,6 +1001,10 @@ span.showMore {
 
 div.postCategories {
   margin: 12px 0 4px 0; }
+
+a.postCategories {
+  display: block;
+  padding: 12px 0 4px 0; }
 
 a.categoryTag,
 span.categoryTag {
@@ -2130,11 +2134,11 @@ iframe {
     grid-column-gap: 12px !important; }
     div.items article {
       width: calc((100vw - 36px) / 2); }
-      div.items article a figure {
+      div.items article figure {
         margin: 0;
         height: calc(((100vw - 36px) / 2) / 4 * 3);
         background: transparent; }
-        div.items article a figure img {
+        div.items article figure a img {
           width: calc((100vw - 36px) / 2);
           height: calc(((100vw - 36px) / 2) / 4 * 3); }
       div.items article h3 {

--- a/style.scss
+++ b/style.scss
@@ -3,7 +3,7 @@
 Theme Name: kikoiro1
 Author: Hironobu Kimura
 Author URI: https://www.emotionale.jp/
-Version: 2.52
+Version: 2.53
 
 kikoiro1 is based on Underscores twentynineteen by WordPress team.
 twentynineteen is distributed under the terms of the GNU GPL v2 or later.

--- a/style.scss
+++ b/style.scss
@@ -925,31 +925,40 @@ div.items {
 		width: 280px;
 		line-height: 150%;
 
+		> a {
+			color: #000000;
+			cursor: pointer;
+			display: block;
+			@media (hover: hover) {
+				&:hover {
+					figure {
+							opacity: 0.7;
+					}
+					h3 span {
+						border-bottom: 1px solid $underLineGray;
+					}
+				}
+			}
+		}
+
 		figure {
 			margin: 0;
 			height: 210px;
 			background: #ffffff;
-			a {
-				transition: opacity 0.3s;
-				@media (hover: hover) {
-					&:hover {
-						opacity: 0.7;
-						cursor: pointer;
-					}
-				}
-				img {
-					width: 280px;
-					height: 210px;
-					object-fit: cover;
-				}
+			transition: opacity 0.3s;
+			img {
+				width: 280px;
+				height: 210px;
+				object-fit: cover;
 			}
 		}
 		h3 {
 			font-size: 18ox;
 			line-height: 150%;
 			margin: 0 0 6px 0;
-			a {
-				@extend .linkWithAnimatedUnderLine;
+			span {
+				border-bottom: 1px solid transparent;
+				transition: border-color 0.2s;
 			}
 		}
 		div.entry-content {
@@ -1086,7 +1095,8 @@ span.showMore {
 div.postCategories {
 	margin: 12px 0 4px 0;
 }
-a.categoryTag {
+a.categoryTag,
+span.categoryTag {
 	background-color: $categoryColorGreen;
 	font-size: 11px;
 	display: inline-block;
@@ -1180,6 +1190,17 @@ section.widget_top-posts {
 		li {
 			margin: 0 0 16px 0;
 			display: flex;
+			@media (hover: hover) {
+				&:hover {
+					img {
+						cursor: pointer;
+						opacity: 0.7;
+					}
+					div.widgets-list-layout-links a {
+						border-bottom: 1px solid $underLineGray;
+					}
+				}
+			}
 			a {
 				img {
 					float: none;
@@ -1187,22 +1208,34 @@ section.widget_top-posts {
 					width: 48px !important;
 					height: 48px !important;
 					transition: opacity 0.3s;
-					@media (hover: hover) {
-						&:hover {
-							cursor: pointer;
-							opacity: 0.7;
-						}
-						float: none;
-					}
 				}
 			}
 			div.widgets-list-layout-links {
 				float: none;
 				width: auto;
-				margin-left: 8px;
 				display: inline-block;
 				line-height: 150%;
+				position: relative;
+				width: 100%;
 				a {
+					border-bottom: 1px solid transparent;
+					transition: border-color 0.2s;
+					&:before {
+						content: "";
+						display: inline-block;
+						width: 8px;
+						height: 48px;
+						float: left;
+					}
+					&:after {
+						content: "";
+						position: absolute;
+						top: 0;
+						left: 0;
+						right: 0;
+						bottom: 0;
+						z-index: 1;
+					}
 					@extend .linkWithAnimatedUnderLine;
 				}
 			}
@@ -2404,11 +2437,11 @@ iframe {
 
 		article {
 			width: calc((100vw - 36px) / 2);
-			figure {
+			a {
+				figure {
 				margin: 0;
 				height: calc(((100vw - 36px) / 2) / 4 * 3);
 				background: transparent;
-				a {
 					img {
 						width: calc((100vw - 36px) / 2);
 						height: calc(((100vw - 36px) / 2) / 4 * 3);

--- a/style.scss
+++ b/style.scss
@@ -924,10 +924,10 @@ div.items {
 		display: block;
 		width: 280px;
 		line-height: 150%;
-		cursor: pointer;
 		a {
 			color: #000000;
-			display: block;
+			display: inline-block;
+			cursor: pointer;
 		}
 		@media (hover: hover) {
 			&:hover {
@@ -1095,12 +1095,7 @@ span.showMore {
 div.postCategories {
 	margin: 12px 0 4px 0;
 }
-a.postCategories {
-	display: block;
-	padding: 12px 0 4px 0;
-}
-a.categoryTag,
-span.categoryTag {
+a.categoryTag {
 	background-color: $categoryColorGreen;
 	font-size: 11px;
 	display: inline-block;

--- a/style.scss
+++ b/style.scss
@@ -924,32 +924,32 @@ div.items {
 		display: block;
 		width: 280px;
 		line-height: 150%;
-
-		> a {
+		cursor: pointer;
+		a {
 			color: #000000;
-			cursor: pointer;
 			display: block;
-			@media (hover: hover) {
-				&:hover {
-					figure {
-							opacity: 0.7;
-					}
-					h3 span {
-						border-bottom: 1px solid $underLineGray;
-					}
+		}
+		@media (hover: hover) {
+			&:hover {
+				figure {
+					opacity: 0.7;
+				}
+				h3 span {
+					border-bottom: 1px solid $underLineGray;
 				}
 			}
 		}
-
 		figure {
 			margin: 0;
 			height: 210px;
 			background: #ffffff;
 			transition: opacity 0.3s;
-			img {
-				width: 280px;
-				height: 210px;
-				object-fit: cover;
+			a {
+				img {
+					width: 280px;
+					height: 210px;
+					object-fit: cover;
+				}
 			}
 		}
 		h3 {
@@ -1094,6 +1094,10 @@ span.showMore {
 
 div.postCategories {
 	margin: 12px 0 4px 0;
+}
+a.postCategories {
+	display: block;
+	padding: 12px 0 4px 0;
 }
 a.categoryTag,
 span.categoryTag {
@@ -2437,11 +2441,11 @@ iframe {
 
 		article {
 			width: calc((100vw - 36px) / 2);
-			a {
-				figure {
+			figure {
 				margin: 0;
 				height: calc(((100vw - 36px) / 2) / 4 * 3);
 				background: transparent;
+				a {
 					img {
 						width: calc((100vw - 36px) / 2);
 						height: calc(((100vw - 36px) / 2) / 4 * 3);

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -14,22 +14,24 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<a href="<?php echo esc_url( get_permalink() ); ?>">
-		<figure class="post-thumbnail">
+	<figure class="post-thumbnail">
+		<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 			<?php echoPostThumbnail('post-thumbnail', true); ?>
-		</figure>
-		<?php
-			$categories = get_the_category();
-			$output = '<div class="postCategories">';
-			if ( $categories ) {
-				foreach ( $categories as $category ) {
-					$output .= '<span class="categoryTag">' . $category->cat_name . '</span>';
-				}
+		</a>
+	</figure>
+	<?php
+		$categories = get_the_category();
+		if ( $categories ) {
+			foreach ( $categories as $category ) {
+				$output = '<a class="postCategories" href="' . get_category_link( $category->term_id ) . '">';
+				$output .= '<span class="categoryTag">' . $category->cat_name . '</span>';
+				$output .= '</a>';
+				echo $output;
 			}
-			$output .= '</div>';
-			echo $output;
-			the_title( '<h3 class="entry-title"><span>', '</span></h3>' );
-		?>
+		}
+	?>
+	<a href="<?php echo esc_url( get_permalink() ); ?>">
+		<?php the_title( '<h3 class="entry-title"><span>', '</span></h3>' ); ?>
 		<?php echo wp_trim_excerpt(); ?>
 		<div class="postDate"><?php echo get_the_date(); ?></div>
 	</a>

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -14,23 +14,23 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<figure class="post-thumbnail">
-		<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+	<a href="<?php echo esc_url( get_permalink() ); ?>">
+		<figure class="post-thumbnail">
 			<?php echoPostThumbnail('post-thumbnail', true); ?>
-		</a>
-	</figure>
-	<?php
-		$categories = get_the_category();
-		$output = '<div class="postCategories">';
-		if ( $categories ) {
-			foreach ( $categories as $category ) {
-				$output .= '<a href="' . get_category_link( $category->term_id ) . '" class="categoryTag">' . $category->cat_name . '</a>';
+		</figure>
+		<?php
+			$categories = get_the_category();
+			$output = '<div class="postCategories">';
+			if ( $categories ) {
+				foreach ( $categories as $category ) {
+					$output .= '<span class="categoryTag">' . $category->cat_name . '</span>';
+				}
 			}
-		}
-		$output .= '</div>';
-		echo $output;
-		the_title( sprintf( '<h3 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h3>' );
-	?>
-	<?php echo wp_trim_excerpt(); ?>
-	<div class="postDate"><?php echo get_the_date(); ?></div>
+			$output .= '</div>';
+			echo $output;
+			the_title( '<h3 class="entry-title"><span>', '</span></h3>' );
+		?>
+		<?php echo wp_trim_excerpt(); ?>
+		<div class="postDate"><?php echo get_the_date(); ?></div>
+	</a>
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -21,14 +21,14 @@
 	</figure>
 	<?php
 		$categories = get_the_category();
+		$output = '<div class="postCategories">';
 		if ( $categories ) {
 			foreach ( $categories as $category ) {
-				$output = '<a class="postCategories" href="' . get_category_link( $category->term_id ) . '">';
-				$output .= '<span class="categoryTag">' . $category->cat_name . '</span>';
-				$output .= '</a>';
-				echo $output;
+				$output .= '<a href="' . get_category_link( $category->term_id ) . '" class="categoryTag">' . $category->cat_name . '</a>';
 			}
 		}
+		$output .= '</div>';
+		echo $output;
 	?>
 	<a href="<?php echo esc_url( get_permalink() ); ?>">
 		<?php the_title( '<h3 class="entry-title"><span>', '</span></h3>' ); ?>


### PR DESCRIPTION
@hirokimu 表示と動作について、ご確認をお願いいたしますm(_ _)m

### TOP（検索ページ、カテゴリページ）記事一覧
ひとまとめにaタグでリンクにするため、いったんカテゴリのリンクを外しています。
もしカテゴリリンクが必要な場合、a要素を分割するか、
objectタグを利用するよう変更しますのでお知らせください。
※ 一応.itemsのスタイルの影響範囲についてテーマ全体を検索しました。他のページには影響なさそうでした。

### POPULARウィジェット
HTMLタグの構造はそのまま、CSSでクリック可能領域を広げました。

### 悩ましかった点
`@extend .linkWithAnimatedUnderLineFeature`
hoverが親子関係になったため上記スタイルの継承を諦め、
それぞれの要素にスタイルをあてております。
